### PR TITLE
Update release.yml trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   validate:


### PR DESCRIPTION
GitHub changed workflows to not trigger on the created event for releases. Update to use the published event.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release